### PR TITLE
Add `local.set` test for local preservation of `loop`s

### DIFF
--- a/tests/local-set.wast
+++ b/tests/local-set.wast
@@ -1,0 +1,19 @@
+(module
+    (func (export "test") (param i32) (result i32)
+        (local.get 0) ;; actual return value
+        (loop $continue (result i32)
+            (if (result i32)
+                (i32.eq (local.get 0) (i32.const -1))
+                (then (i32.const 0))
+                (else
+                    (local.set 0 (i32.const -1))
+                    (br $continue)
+                )
+            )
+        )
+        (drop) ;; drop results from `loop`
+    )
+)
+
+(assert_return (invoke "test" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "test" (i32.const 1)) (i32.const 1))


### PR DESCRIPTION
Wasmi so far did not preserve locals when entering Wasm `loop`s because we couldn't come up with a test case and thought it was impossible. Well .. now @davnavr found one in https://github.com/wasmi-labs/wasmi/issues/1748.